### PR TITLE
DACの出力値を500 mVに正確に調整

### DIFF
--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -69,7 +69,7 @@ UART_HandleTypeDef huart5;
   static char uart_buf[100];
 
   // DAC and ADC test variables
-  static uint32_t dac_value = 625;  // 固定値（約0.5V）
+  static uint32_t dac_value = 620;  // 固定値（500 mV）
   static uint32_t adc_value = 0;
   // static uint8_t dac_direction = 1; // 1 for increasing, 0 for decreasing (不要なのでコメントアウト)
 
@@ -254,9 +254,9 @@ int main(void)
   printf("ADC Calibrated and Ready\r\n");
 
   // Set initial DAC value
-  dac_value = 625; // Middle value (1.65V for 3.3V reference)
+  dac_value = 620; // 500 mV for 3.3V reference
   HAL_DAC_SetValue(&hdac1, DAC_CHANNEL_1, DAC_ALIGN_12B_R, dac_value);
-  printf("Initial DAC value set to: %lu (should be ~1.65V)\r\n", dac_value);
+  printf("Initial DAC value set to: %lu (should be 500 mV)\r\n", dac_value);
 
   printf("Starting ID Register Read Test...\r\n");
 


### PR DESCRIPTION
## 概要
DACの出力値を503 mVから正確に500 mVに調整しました。

## 変更内容
- DAC値を625から620に変更
  - 計算式: 620 * 3300 / 4095 = 500.12 mV ≈ 500 mV
  - 以前: 625 * 3300 / 4095 = 503.91 mV ≈ 503 mV
- 初期化時のDAC値設定も同様に変更
- コメントを「約0.5V」から「500 mV」に更新

## テスト計画
- [ ] コンパイルが正常に完了することを確認
- [ ] 実機でDAC出力が500 mVになっていることを確認
- [ ] ADCで読み取った値が500 mV付近であることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)