### PR TITLE
LCD画像表示をモノクロからカラー表示に変更

### DIFF
--- a/Core/Inc/lcd.h
+++ b/Core/Inc/lcd.h
@@ -9,6 +9,7 @@ void LCD_FillWhite(void);
 void LCD_SendLine4bit(uint16_t y, const uint8_t *buf);
 void LCD_DrawString4bit(uint16_t y0, const char *str);
 void LCD_DrawImage(void);
+void LCD_DrawImageColorful(void);
 
 /* アニメーション関数 */
 void LCD_ScrollText(uint16_t y0, const char *str, uint16_t scroll_offset);

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -212,8 +212,8 @@ int main(void)
   LCD_Init();
   printf("LCD Initialized\r\n");
 
-  // 画像を表示
-  LCD_DrawImage();
+  // 画像を表示（カラー版）
+  LCD_DrawImageColorful();
   HAL_Delay(3000);
   LCD_FillWhite(); // 一時的にコメントアウト
 


### PR DESCRIPTION
## 概要
LCD画像表示機能をモノクロからカラー表示に変更しました。既存のモノクロ画像データを活用し、4bitカラー表示でより魅力的な表示を実現します。

## 変更内容

### 新機能追加
- **LCD_DrawImageColorful()関数**: 新規追加
  - モノクロ画像データを4bitカラー表示に変換
  - 位置ベースのカラーバリエーション機能
  - 黒い部分に青/緑/赤のパターン表示
  - 白い部分に高さに応じた色調変化（黄→シアン→白）

### 既存機能改善
- **LCD_DrawImage()関数**: 8bppモノクロデータ対応に修正
  - 24bppカラー想定から実際の8bppモノクロに対応
  - グレーレベルのカラーマッピング機能追加

### 設定変更
- main.cでカラー表示関数を使用するよう変更
- ヘッダファイルに新関数プロトタイプを追加

## 技術仕様
- 4bitカラー（16色）表示対応
- 176x176ピクセル画像サイズ対応
- モノクロデータ（0x00=黒、0xFF=白）からの変換

## テスト計画
- [ ] コンパイルが正常に完了することを確認
- [ ] 実機でカラー画像が正しく表示されることを確認
- [ ] 文字表示機能が引き続き正常に動作することを確認
- [ ] メモリ使用量に問題がないことを検証

## 互換性
- 文字表示機能は変更なし
- 既存のモノクロ画像データをそのまま使用
- LCD初期化処理は変更なし

🤖 Generated with [Claude Code](https://claude.ai/code)