### PR TITLE
Add ADC2 monitoring and display functionality

### DIFF
--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -92,6 +92,7 @@ UART_HandleTypeDef huart5;
   volatile uint8_t current_voltage_index = 0;  // 現在の電圧インデックス（割り込みで変更されるためvolatile）
   volatile uint32_t dac_value = 124;  // 初期値は100mV（割り込みで変更されるためvolatile）
   static uint32_t adc_value = 0;
+  static uint32_t adc2_value = 0;  // ADC2の測定値
   static volatile uint8_t button_was_pressed = 0;  // ボタン押下検出フラグ
 
   // ADS1299のSPIハンドル (MX_SPI2_Init()で初期化されるもの)
@@ -266,13 +267,21 @@ int main(void)
   }
   printf("OPAMP2 Started\r\n");
   
-  // Calibrate ADC
+  // Calibrate ADC1
   if (HAL_ADCEx_Calibration_Start(&hadc1, ADC_SINGLE_ENDED) != HAL_OK) {
-      printf("ADC Calibration Error!\r\n");
-      LCD_DrawString4bit(90, "ADC Error");
+      printf("ADC1 Calibration Error!\r\n");
+      LCD_DrawString4bit(90, "ADC1 Error");
       Error_Handler();
   }
-  printf("ADC Calibrated and Ready\r\n");
+  printf("ADC1 Calibrated and Ready\r\n");
+  
+  // Calibrate ADC2
+  if (HAL_ADCEx_Calibration_Start(&hadc2, ADC_SINGLE_ENDED) != HAL_OK) {
+      printf("ADC2 Calibration Error!\r\n");
+      LCD_DrawString4bit(110, "ADC2 Error");
+      Error_Handler();
+  }
+  printf("ADC2 Calibrated and Ready\r\n");
   // Set initial DAC value to match the first voltage level (100mV)
   dac_value = dac_voltage_levels[current_voltage_index];
   HAL_DAC_SetValue(&hdac1, DAC_CHANNEL_1, DAC_ALIGN_12B_R, dac_value);
@@ -348,19 +357,44 @@ int main(void)
     
     adc_value = adc_sum / num_samples; // 平均値を計算
     
+    // Read ADC2 value (OPAMP2 via voltage follower) - 複数回測定して平均化
+    uint32_t adc2_sum = 0;
+    const uint8_t num_samples2 = 10; // 10回測定して平均
+    
+    for (uint8_t i = 0; i < num_samples2; i++) {
+        if (HAL_ADC_Start(&hadc2) != HAL_OK) {
+            printf("ADC2 Start Error!\r\n");
+            break;
+        }
+        
+        if (HAL_ADC_PollForConversion(&hadc2, HAL_MAX_DELAY) == HAL_OK) {
+            adc2_sum += HAL_ADC_GetValue(&hadc2);
+        }
+        HAL_ADC_Stop(&hadc2);
+        HAL_Delay(1); // 測定間の短い遅延
+    }
+    
+    adc2_value = adc2_sum / num_samples2; // 平均値を計算
+    
     // Calculate voltage values for display (mV単位で整数演算)
     uint32_t dac_voltage_mv = (dac_value * VREF_MV) / ADC_MAX_VALUE;
     uint32_t adc_voltage_mv = (adc_value * VREF_MV) / ADC_MAX_VALUE;
+    uint32_t adc2_voltage_mv = (adc2_value * VREF_MV) / ADC_MAX_VALUE;
     
-    // Calculate current from ADC voltage (μA単位)
+    // Calculate current from ADC1 voltage (μA単位)
     // I = (V_adc - 0.5V) / (151kΩ) where V_adc is in V, I is in A
     // Convert to μA: I_uA = (V_adc - 0.5V) / 151000Ω * 1000000
     float voltage_v = adc_voltage_mv / 1000.0f; // mV to V
     float current_ua = (voltage_v - 0.5f) / 151000.0f * 1000000.0f; // Calculate current in μA
     
+    // Calculate current from ADC2 voltage (μA単位) - OPAMP2経由
+    float voltage2_v = adc2_voltage_mv / 1000.0f; // mV to V
+    float current2_ua = (voltage2_v - 0.5f) / 151000.0f * 1000000.0f; // Calculate current in μA
+    
     // Output DAC and ADC values via UART
-    printf("DAC:%lu %lumV -> ADC:%lu %lumV (%.1f uA)\r\n", 
-           dac_value, dac_voltage_mv, adc_value, adc_voltage_mv, current_ua);
+    printf("DAC:%lu %lumV -> ADC1:%lu %lumV (%.1f uA) | ADC2:%lu %lumV (%.1f uA)\r\n", 
+           dac_value, dac_voltage_mv, adc_value, adc_voltage_mv, current_ua, 
+           adc2_value, adc2_voltage_mv, current2_ua);
     
     // Update LCD display every 10 iterations to reduce flicker
     static uint32_t lcd_update_counter = 0;
@@ -377,19 +411,25 @@ int main(void)
         snprintf(dac_str, sizeof(dac_str), "DAC: %lumV [%d/5]", dac_voltage_mv, current_voltage_index + 1);
         LCD_DrawString4bit(30, dac_str);
         
-        // Display ADC voltage (mV)
+        // Display ADC1 voltage (mV)
         char adc_str[32];
-        snprintf(adc_str, sizeof(adc_str), "ADC: %lu mV", adc_voltage_mv);
+        snprintf(adc_str, sizeof(adc_str), "ADC1: %lu mV", adc_voltage_mv);
         LCD_DrawString4bit(50, adc_str);
         
-        // Display calculated current (μA)
-        char current_str[32];
-        snprintf(current_str, sizeof(current_str), "Current: %.1f uA", current_ua);
-        LCD_DrawString4bit(70, current_str);
+        // Display ADC2 voltage (mV)
+        char adc2_str[32];
+        snprintf(adc2_str, sizeof(adc2_str), "ADC2: %lu mV", adc2_voltage_mv);
+        LCD_DrawString4bit(70, adc2_str);
         
-        // Display button instruction
-        LCD_DrawString4bit(70, "Press USER button");
-        LCD_DrawString4bit(90, "to shift voltage");
+        // Display calculated current from ADC1 (μA)
+        char current_str[32];
+        snprintf(current_str, sizeof(current_str), "I1: %.1f uA", current_ua);
+        LCD_DrawString4bit(90, current_str);
+        
+        // Display calculated current from ADC2 (μA)
+        char current2_str[32];
+        snprintf(current2_str, sizeof(current2_str), "I2: %.1f uA", current2_ua);
+        LCD_DrawString4bit(110, current2_str);
     }
     
     // Keep existing ADS1299 functionality (reduced frequency)


### PR DESCRIPTION
## Summary
- ADC2の監視と表示機能を追加
- ADC1と同様の実装でデュアルチャンネル監視が可能
- LCDとUART両方で出力表示

## Changes
### ADC2測定機能
- ADC2用の変数`adc2_value`を追加
- システム初期化時にADC2キャリブレーション処理を追加
- ADC1と同様の10回サンプリング平均化による測定実装
- OPAMP2経由での電圧フォロワー測定

### 電流計算
- ADC2電圧値から電流値計算を実装
- ADC1と同じ計算式: `I = (V_adc - 0.5V) / 151kΩ`
- 結果をマイクロアンペア単位で表示

### LCD表示更新
- **ADC1**: 50行目に電圧値表示
- **ADC2**: 70行目に電圧値表示  
- **I1**: 90行目にADC1電流値表示
- **I2**: 110行目にADC2電流値表示

### UART出力更新
- 出力フォーマット: `DAC:xxx mV -> ADC1:xxx mV (x.x uA) | ADC2:xxx mV (x.x uA)`
- 両チャンネルの電圧と電流を同時監視可能

## Technical Details
### 実装仕様
- ADC2もADC1と同様に12ビット分解能
- OPAMP2を電圧フォロワーとして使用
- 複数サンプル平均化による測定精度向上
- エラーハンドリングの実装

### 表示レイアウト
```
Current Monitor         # 10行目
DAC: xxxmV [n/5]       # 30行目
ADC1: xxx mV           # 50行目
ADC2: xxx mV           # 70行目
I1: x.x uA             # 90行目
I2: x.x uA             # 110行目
```

## Test Plan
- [ ] ADC2キャリブレーションが正常に完了することを確認
- [ ] ADC2測定値がLCDに正しく表示されることを確認
- [ ] UART出力で両チャンネルの値が出力されることを確認
- [ ] ADC1とADC2の測定値が独立して動作することを確認
- [ ] 電流計算が正しく行われることを確認

## Benefits
- デュアルチャンネル測定による比較分析が可能
- OPAMP1/OPAMP2両方の動作確認
- より詳細な電流測定監視
- 測定システムの冗長性向上

🤖 Generated with [Claude Code](https://claude.ai/code)