### PR TITLE
ボタン制御によるLCD画像表示機能の実装

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -7,7 +7,9 @@
       "Bash(git reset:*)",
       "Bash(git commit:*)",
       "Bash(git push:*)",
-      "Bash(gh pr view:*)"
+      "Bash(gh pr view:*)",
+      "Bash(gh pr edit:*)",
+      "Bash(git pull:*)"
     ],
     "deny": [],
     "ask": []


### PR DESCRIPTION
## 概要
- 起動時のLCD画像表示をボタン制御に変更
- 1回目のボタン押下まで画像を表示し続ける
- 2回目以降のボタン押下はDAC電圧値変更として動作

## 変更内容
### Core/Src/main.c
- `button_press_count`: ボタン押下回数をカウントする変数を追加
- `image_display_mode`: 画像表示モードを管理するフラグを追加（1:表示中、0:通常モード）
- 起動時の3秒間表示を削除し、ボタン押下まで表示を継続
- ボタン押下処理を分岐：
  - 1回目: 画像表示モードを終了し、通常のモニタリング画面へ遷移
  - 2回目以降: DAC電圧値を変更（100mV → 200mV → 300mV → 400mV → 500mV）

## テスト手順
- [ ] プログラムを起動し、LCD画像が表示されることを確認
- [ ] ユーザーボタンを1回押下し、通常のDAC/ADCモニタリング画面に遷移することを確認
- [ ] 2回目以降のボタン押下でDAC電圧値が切り替わることを確認
- [ ] UART出力でボタン押下回数と状態遷移が確認できることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)